### PR TITLE
radarr: Add support for Test in Aphrodite. (#1)

### DIFF
--- a/TorrentCleanup.py
+++ b/TorrentCleanup.py
@@ -29,6 +29,8 @@ log = logging.getLogger("TorrentCleanup")
 # Retrieve Required Variables
 if os.environ.get('sonarr_eventtype') == "Test":
     sys.exit(0)
+elif os.environ.get('radarr_eventtype') == "Test":
+    sys.exit(0)
 elif os.environ.get('lidarr_eventtype') == "Test":
     sys.exit(0)
 elif 'sonarr_eventtype' in os.environ:


### PR DESCRIPTION
Radarr Aphrodite requires scripts to exit with 0 during saving, otherwise they don't will be added to Radarr.

Tested on Radarr Aphrodite 3.0.0.2608 (latest as of 31/01/2020)